### PR TITLE
게시판 입력 요소들 추가 및 게시판 조회 필터링 기능 추가

### DIFF
--- a/src/main/java/HYU/FishShip/Core/Entity/Posts.java
+++ b/src/main/java/HYU/FishShip/Core/Entity/Posts.java
@@ -21,6 +21,7 @@ public class Posts {
     private Long post_id;
 
     private String category;
+
     private String title;
     private String company;
     private String location;
@@ -33,6 +34,23 @@ public class Posts {
 
     private ZonedDateTime created_at;
     private ZonedDateTime updated_at;
+
+    // 채용공고, 인턴공고 필터링 필드
+    private String jobTitle;    // 직무
+    private Integer experience; // 경력 (1년 단위)
+    private String education;   // 학력 (초대졸, 고졸, 대졸, 석사/박사, 학력무관)
+
+    // 대외활동, 교육/강연 필터링 필드
+    private String activityField;  // 분야
+    private Integer activityDuration;  // 활동 기간 (1개월 단위), 교육/강연 필터링 필드에서는 1일 단위
+    private String hostingOrganization; // 주최기관 (공공기관/공기업, 대기업 등)
+
+    // 교육/강연 필터링 필드
+    private String onlineOrOffline;    // 온/오프라인 여부 (전체, 온라인, 오프라인, 혼합)
+
+    // 공모전 필터링 필드
+    private String targetAudience; // 대상 (대학생, 일반인, 제한없음)
+    private String contestBenefits; // 공모전 혜택 (상금, 상장, 상용화 등)
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "post_id")

--- a/src/main/java/HYU/FishShip/Core/Repository/PostsRepository.java
+++ b/src/main/java/HYU/FishShip/Core/Repository/PostsRepository.java
@@ -2,6 +2,39 @@ package HYU.FishShip.Core.Repository;
 
 import HYU.FishShip.Core.Entity.Posts;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface PostsRepository extends JpaRepository<Posts, Long> {
+
+    // 필터링된 게시물 조회 (채용공고, 인턴공고, 대외활동 등)
+    @Query("SELECT p FROM Posts p WHERE " +
+            "(COALESCE(:category, '') = '' OR p.category = :category) AND " +
+            "(COALESCE(:jobTitle, '') = '' OR p.jobTitle LIKE %:jobTitle%) AND " +
+            "(COALESCE(:experience, -1) = -1 OR p.experience = :experience) AND " +
+            "(COALESCE(:education, '') = '' OR p.education LIKE %:education%) AND " +
+            "(COALESCE(:activityField, '') = '' OR p.activityField LIKE %:activityField%) AND " +
+            "(COALESCE(:activityDuration, -1) = -1 OR p.activityDuration = :activityDuration) AND " +
+            "(COALESCE(:hostingOrganization, '') = '' OR p.hostingOrganization LIKE %:hostingOrganization%) AND " +
+            "(COALESCE(:onlineOrOffline, '') = '' OR p.onlineOrOffline LIKE %:onlineOrOffline%) AND " +
+            "(COALESCE(:targetAudience, '') = '' OR p.targetAudience LIKE %:targetAudience%) AND " +
+            "(COALESCE(:contestBenefits, '') = '' OR p.contestBenefits LIKE %:contestBenefits%) AND" +
+            "(COALESCE(:location, '') = '' OR p.location LIKE %:location%)")
+    List<Posts> findByFilters(
+            @Param("category") String category,
+            @Param("jobTitle") String jobTitle,
+            @Param("experience") Integer experience,
+            @Param("education") String education,
+            @Param("activityField") String activityField,
+            @Param("activityDuration") Integer activityDuration,
+            @Param("hostingOrganization") String hostingOrganization,
+            @Param("onlineOrOffline") String onlineOrOffline,
+            @Param("targetAudience") String targetAudience,
+            @Param("contestBenefits") String contestBenefits,
+            @Param("location") String location
+    );
 }

--- a/src/main/java/HYU/FishShip/Feature/Posts/Controller/PostsController.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Controller/PostsController.java
@@ -3,6 +3,7 @@ package HYU.FishShip.Feature.Posts.Controller;
 
 import HYU.FishShip.Feature.Posts.Dto.PostsRequestDto;
 import HYU.FishShip.Feature.Posts.Dto.PostsResponseDto;
+import HYU.FishShip.Feature.Posts.Filter.PostFilterCriteria;
 import HYU.FishShip.Feature.Posts.Service.PostsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -52,6 +53,105 @@ public class PostsController {
     public ResponseEntity<PostsResponseDto> getPostById(@PathVariable("post_id") Long post_id) {
         PostsResponseDto response = postsService.getPostById(post_id);
         return ResponseEntity.ok(response);
+    }
+
+    // 필터링된 공고 목록 조회
+    // 채용공고 필터링
+    @GetMapping("/employee")
+    public ResponseEntity<List<PostsResponseDto>> getRecruitmentPosts(
+            @RequestParam(required = false) String jobTitle,
+            @RequestParam(required = false) Integer experience,
+            @RequestParam(required = false) String education,
+            @RequestParam(required = false) String location) {
+
+        PostFilterCriteria criteria = new PostFilterCriteria();
+        criteria.setCategory("채용공고");
+        criteria.setJobTitle(jobTitle);
+        criteria.setExperience(experience);
+        criteria.setEducation(education);
+        criteria.setLocation(location);
+
+        List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
+
+        return ResponseEntity.ok(filteredPosts);
+    }
+
+    // 인턴공고 필터링
+    @GetMapping("/intern")
+    public ResponseEntity<List<PostsResponseDto>> getInternshipPosts(
+            @RequestParam(required = false) String jobTitle,
+            @RequestParam(required = false) Integer experience,
+            @RequestParam(required = false) String education,
+            @RequestParam(required = false) String location) {
+
+        PostFilterCriteria criteria = new PostFilterCriteria();
+        criteria.setCategory("인턴공고");
+        criteria.setJobTitle(jobTitle);
+        criteria.setExperience(experience);
+        criteria.setEducation(education);
+        criteria.setLocation(location);
+
+        List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
+
+        return ResponseEntity.ok(filteredPosts);
+    }
+
+    // 대외활동공고 필터링
+    @GetMapping("/external")
+    public ResponseEntity<List<PostsResponseDto>> getActivityPosts(
+            @RequestParam(required = false) String activityField,
+            @RequestParam(required = false) Integer activityDuration,
+            @RequestParam(required = false) String hostingOrganization,
+            @RequestParam(required = false) String location) {
+
+        PostFilterCriteria criteria = new PostFilterCriteria();
+        criteria.setCategory("대외활동");
+        criteria.setActivityField(activityField);
+        criteria.setActivityDuration(activityDuration);
+        criteria.setHostingOrganization(hostingOrganization);
+        criteria.setLocation(location);
+
+        List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
+
+        return ResponseEntity.ok(filteredPosts);
+    }
+
+    // 교육/강연공고 필터링
+    @GetMapping("/lecture")
+    public ResponseEntity<List<PostsResponseDto>> getEducationPosts(
+            @RequestParam(required = false) String activityField,
+            @RequestParam(required = false) Integer activityDuration,
+            @RequestParam(required = false) String onlineOrOffline,
+            @RequestParam(required = false) String location) {
+
+        PostFilterCriteria criteria = new PostFilterCriteria();
+        criteria.setCategory("교육/강연");
+        criteria.setActivityField(activityField);
+        criteria.setActivityDuration(activityDuration);
+        criteria.setOnlineOrOffline(onlineOrOffline);
+        criteria.setLocation(location);
+
+        List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
+
+        return ResponseEntity.ok(filteredPosts);
+    }
+
+    // 공모전공고 필터링
+    @GetMapping("/contest")
+    public ResponseEntity<List<PostsResponseDto>> getContestPosts(
+            @RequestParam(required = false) String targetAudience,
+            @RequestParam(required = false) String contestBenefits,
+            @RequestParam(required = false) String location) {
+
+        PostFilterCriteria criteria = new PostFilterCriteria();
+        criteria.setCategory("공모전");
+        criteria.setTargetAudience(targetAudience);
+        criteria.setContestBenefits(contestBenefits);
+        criteria.setLocation(location);
+
+        List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
+
+        return ResponseEntity.ok(filteredPosts);
     }
 }
 

--- a/src/main/java/HYU/FishShip/Feature/Posts/Controller/PostsController.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Controller/PostsController.java
@@ -64,12 +64,13 @@ public class PostsController {
             @RequestParam(required = false) String education,
             @RequestParam(required = false) String location) {
 
-        PostFilterCriteria criteria = new PostFilterCriteria();
-        criteria.setCategory("채용공고");
-        criteria.setJobTitle(jobTitle);
-        criteria.setExperience(experience);
-        criteria.setEducation(education);
-        criteria.setLocation(location);
+        PostFilterCriteria criteria = PostFilterCriteria.builder()
+                .category("채용공고")
+                .jobTitle(jobTitle)
+                .experience(experience)
+                .education(education)
+                .location(location)
+                .build();
 
         List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
 
@@ -84,12 +85,13 @@ public class PostsController {
             @RequestParam(required = false) String education,
             @RequestParam(required = false) String location) {
 
-        PostFilterCriteria criteria = new PostFilterCriteria();
-        criteria.setCategory("인턴공고");
-        criteria.setJobTitle(jobTitle);
-        criteria.setExperience(experience);
-        criteria.setEducation(education);
-        criteria.setLocation(location);
+        PostFilterCriteria criteria = PostFilterCriteria.builder()
+                .category("인턴공고")
+                .jobTitle(jobTitle)
+                .experience(experience)
+                .education(education)
+                .location(location)
+                .build();
 
         List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
 
@@ -104,12 +106,13 @@ public class PostsController {
             @RequestParam(required = false) String hostingOrganization,
             @RequestParam(required = false) String location) {
 
-        PostFilterCriteria criteria = new PostFilterCriteria();
-        criteria.setCategory("대외활동");
-        criteria.setActivityField(activityField);
-        criteria.setActivityDuration(activityDuration);
-        criteria.setHostingOrganization(hostingOrganization);
-        criteria.setLocation(location);
+        PostFilterCriteria criteria = PostFilterCriteria.builder()
+                .category("대외활동")
+                .activityField(activityField)
+                .activityDuration(activityDuration)
+                .hostingOrganization(hostingOrganization)
+                .location(location)
+                .build();
 
         List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
 
@@ -124,12 +127,13 @@ public class PostsController {
             @RequestParam(required = false) String onlineOrOffline,
             @RequestParam(required = false) String location) {
 
-        PostFilterCriteria criteria = new PostFilterCriteria();
-        criteria.setCategory("교육/강연");
-        criteria.setActivityField(activityField);
-        criteria.setActivityDuration(activityDuration);
-        criteria.setOnlineOrOffline(onlineOrOffline);
-        criteria.setLocation(location);
+        PostFilterCriteria criteria = PostFilterCriteria.builder()
+                .category("교육/강연")
+                .activityField(activityField)
+                .activityDuration(activityDuration)
+                .onlineOrOffline(onlineOrOffline)
+                .location(location)
+                .build();
 
         List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
 
@@ -143,11 +147,12 @@ public class PostsController {
             @RequestParam(required = false) String contestBenefits,
             @RequestParam(required = false) String location) {
 
-        PostFilterCriteria criteria = new PostFilterCriteria();
-        criteria.setCategory("공모전");
-        criteria.setTargetAudience(targetAudience);
-        criteria.setContestBenefits(contestBenefits);
-        criteria.setLocation(location);
+        PostFilterCriteria criteria = PostFilterCriteria.builder()
+                .category("공모전")
+                .targetAudience(targetAudience)
+                .contestBenefits(contestBenefits)
+                .location(location)
+                .build();
 
         List<PostsResponseDto> filteredPosts = postsService.getFilteredPosts(criteria);
 

--- a/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsRequestDto.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsRequestDto.java
@@ -25,15 +25,15 @@ public class PostsRequestDto {
 
     private String jobTitle;    // 직무
     private Integer experience; // 경력 (1년 단위)
-    private String education;   // 학력
+    private String education;   // 학력 (초대졸, 고졸, 대졸, 석사/박사, 학력무관)
 
     private String activityField;  // 분야
-    private Integer activityDuration;  // 활동 기간 (1개월 단위)
-    private String hostingOrganization; // 주최기관
+    private Integer activityDuration;  // 활동 기간 (1개월 단위), 교육/강연 필터링 필드에서는 1일 단위
+    private String hostingOrganization; // 주최기관 (공공기관/공기업, 대기업 등)
 
-    private String onlineOrOffline;    // 온/오프라인 여부
-    private String targetAudience;     // 대상
-    private String contestBenefits;    // 공모전 혜택
+    private String onlineOrOffline;    // 온/오프라인 여부 (전체, 온라인, 오프라인, 혼합)
+    private String targetAudience;     // 대상 (대학생, 일반인, 제한없음)
+    private String contestBenefits;    // 공모전 혜택 (상금, 상장, 상용화 등)
 
     private List<String> requirements = new ArrayList<>();
     private List<String> benefits = new ArrayList<>();

--- a/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsRequestDto.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsRequestDto.java
@@ -3,6 +3,7 @@ package HYU.FishShip.Feature.Posts.Dto;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -20,9 +21,25 @@ public class PostsRequestDto {
     private LocalDate start_date;
     private LocalDate end_date;
     private String description;
-    private List<String> requirements;
-    private List<String> benefits;
-    private List<AttachmentDto> attachments;
+
+
+    private String jobTitle;    // 직무
+    private Integer experience; // 경력 (1년 단위)
+    private String education;   // 학력
+
+    private String activityField;  // 분야
+    private Integer activityDuration;  // 활동 기간 (1개월 단위)
+    private String hostingOrganization; // 주최기관
+
+    private String onlineOrOffline;    // 온/오프라인 여부
+    private String targetAudience;     // 대상
+    private String contestBenefits;    // 공모전 혜택
+
+    private List<String> requirements = new ArrayList<>();
+    private List<String> benefits = new ArrayList<>();
+    private List<AttachmentDto> attachments = new ArrayList<>();
+
+
 
     @Getter
     @Setter

--- a/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsResponseDto.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsResponseDto.java
@@ -26,6 +26,19 @@ public class PostsResponseDto {
     private ZonedDateTime created_at;
     private ZonedDateTime updated_at;
 
+    private String jobTitle;  // 직무
+    private Integer experience;  // 경력 (1년 단위)
+    private String education;  // 학력
+
+    private String activityField;  // 분야
+    private Integer activityDuration;  // 활동 기간 (1개월 단위)
+    private String hostingOrganization; // 주최기관
+
+    private String onlineOrOffline; // 온/오프라인 여부
+    private String targetAudience;  // 대상
+    private String contestBenefits; // 공모전 혜택
+
+
     @Getter
     @Setter
     @NoArgsConstructor

--- a/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsResponseDto.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Dto/PostsResponseDto.java
@@ -26,17 +26,17 @@ public class PostsResponseDto {
     private ZonedDateTime created_at;
     private ZonedDateTime updated_at;
 
-    private String jobTitle;  // 직무
-    private Integer experience;  // 경력 (1년 단위)
-    private String education;  // 학력
+    private String jobTitle;    // 직무
+    private Integer experience; // 경력 (1년 단위)
+    private String education;   // 학력 (초대졸, 고졸, 대졸, 석사/박사, 학력무관)
 
     private String activityField;  // 분야
-    private Integer activityDuration;  // 활동 기간 (1개월 단위)
-    private String hostingOrganization; // 주최기관
+    private Integer activityDuration;  // 활동 기간 (1개월 단위), 교육/강연 필터링 필드에서는 1일 단위
+    private String hostingOrganization; // 주최기관 (공공기관/공기업, 대기업 등)
 
-    private String onlineOrOffline; // 온/오프라인 여부
-    private String targetAudience;  // 대상
-    private String contestBenefits; // 공모전 혜택
+    private String onlineOrOffline;    // 온/오프라인 여부 (전체, 온라인, 오프라인, 혼합)
+    private String targetAudience;     // 대상 (대학생, 일반인, 제한없음)
+    private String contestBenefits;    // 공모전 혜택 (상금, 상장, 상용화 등)
 
 
     @Getter

--- a/src/main/java/HYU/FishShip/Feature/Posts/Filter/PostFilterCriteria.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Filter/PostFilterCriteria.java
@@ -1,0 +1,22 @@
+package HYU.FishShip.Feature.Posts.Filter;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PostFilterCriteria {
+    private String category;
+    private String jobTitle;
+    private Integer experience;
+    private String education;
+    private String activityField;
+    private Integer activityDuration;
+    private String hostingOrganization;
+    private String onlineOrOffline;
+    private String targetAudience;
+    private String contestBenefits;
+    private String location;
+}

--- a/src/main/java/HYU/FishShip/Feature/Posts/Service/PostsService.java
+++ b/src/main/java/HYU/FishShip/Feature/Posts/Service/PostsService.java
@@ -10,6 +10,7 @@ import HYU.FishShip.Feature.Posts.Dto.PostsMapper;
 import HYU.FishShip.Feature.Posts.Dto.PostsRequestDto;
 import HYU.FishShip.Feature.Posts.Dto.PostsResponseDto;
 
+import HYU.FishShip.Feature.Posts.Filter.PostFilterCriteria;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +52,15 @@ public class PostsService {
                             .end_date(dto.getEnd_date())
                             .description(dto.getDescription())
                             .updated_at(ZonedDateTime.now())
+                            .jobTitle(dto.getJobTitle())  // 직무
+                            .experience(dto.getExperience())  // 경력
+                            .education(dto.getEducation())  // 학력
+                            .activityField(dto.getActivityField())  // 분야
+                            .activityDuration(dto.getActivityDuration())  // 활동 기간
+                            .hostingOrganization(dto.getHostingOrganization())  // 주최기관
+                            .onlineOrOffline(dto.getOnlineOrOffline())  // 온/오프라인 여부
+                            .targetAudience(dto.getTargetAudience())  // 대상
+                            .contestBenefits(dto.getContestBenefits())
                             .build();
 
 
@@ -106,5 +116,25 @@ public class PostsService {
         Posts post = postsRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 공고가 존재하지 않습니다."));
         return PostsMapper.toDto(post);
+    }
+
+    // 필터링된 공고 목록 조회
+    public List<PostsResponseDto> getFilteredPosts(PostFilterCriteria criteria) {
+        List<Posts> filteredPosts = postsRepository.findByFilters(
+                criteria.getCategory(),
+                criteria.getJobTitle(),
+                criteria.getExperience(),
+                criteria.getEducation(),
+                criteria.getActivityField(),
+                criteria.getActivityDuration(),
+                criteria.getHostingOrganization(),
+                criteria.getOnlineOrOffline(),
+                criteria.getTargetAudience(),
+                criteria.getContestBenefits(),
+                criteria.getLocation()
+        );
+        return filteredPosts.stream()
+                .map(PostsMapper::toDto)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📝 PR 설명
- 채용공고 게시판은 직무, 경력(1년 단위), 지역, 학력(학력 전체, 초대졸, 고졸, 대졸 ,석사/박사, 학력무관)을 기준으로 필터링.
- 인턴공고는 직무, 경력(1개월 단위), 지역, 학력(학력 전체, 초대졸, 고졸, 대졸 ,석사/박사, 학력무관)을 기준으로 필터링.
- 대외활동 게시판은 분야, 활동기간(1개월 단위),지역, 주최기관(공공기관/공기업, 단체/협회/재단, 대기업, 중소기업, 스타트업, 기타)로 필터링.
- 교육/강연 게시판은 분야, 기간(1일 단위), 지역, 온/오프라인(전체, 온라인, 오프라인, 혼합)으로 필터링.
- 공모전 게시판은 분야, 대상(전체, 대학생, 일반인, 제한없음), 주최기관(전체, 공공기관/공기업, 단체/협회/재단, 대기업, 중소기업, 스타트업, 기타), 혜택(전체, 상금, 상장, 상용화, 해외연수, 입사 가산점, 채용 연계, 기타)로 필터링.

이렇게 하여 필터링 기능 추가하였습니다.
새롭게 추가한 필터링 요소들은 옆에 주석으로 설명 적어놓았습니다.

